### PR TITLE
Fix android 16 crashes

### DIFF
--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
@@ -219,7 +219,7 @@ class FastImageViewManager extends SimpleViewManager<FastImageViewWithUrl> imple
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
             return activity.isDestroyed() || activity.isFinishing();
         } else {
-            return activity.isDestroyed() || activity.isFinishing() || activity.isChangingConfigurations();
+            return activity.isFinishing() || activity.isChangingConfigurations();
         }
 
     }


### PR DESCRIPTION
The fix is identical to this PR: https://github.com/DylanVann/react-native-fast-image/pull/552
Docs clearly state that [`isDestroyed`](https://developer.android.com/reference/android/app/Activity#isDestroyed()) is available from API Level 17. 